### PR TITLE
changed default port to 7379

### DIFF
--- a/dice/client.py
+++ b/dice/client.py
@@ -57,7 +57,7 @@ class Client:
     def __init__(
         self,
         host="127.0.0.1",
-        port=6379,
+        port=7379,
         db=0,
         password=None,
         path=None,


### PR DESCRIPTION
This PR changes the default port from 6379 to 7379. This change is necessary to prevent conflicts with DiceDB, which runs on the default port of 7379.