### PR TITLE
feat: code entrypoint added and revamped docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,50 @@
-A CLI for [DiceDB](https://github.com/dicedb/cli) with auto completion and syntax highlighting.
 
-## Development
+# DiceDB CLI with Auto Completion and Syntax Highlighting
 
-```
+
+## Running with Poetry
+
+1. Install [Poetry](https://python-poetry.org/docs/#installation):
+
+   ```bash
+   $ curl -sSL https://install.python-poetry.org | python3 -
+   ```
+
+2. Run the project using Poetry:
+
+   ```bash
+   $ poetry install
+   $ poetry shell
+   $ dice
+
+   Examples | Alternates :
+      - dice
+      - dice -d dsn
+      - dice -h 127.0.0.1 -p 6379
+      - dice -h 127.0.0.1 -p 6379 -a <password>
+      - dice --url redis://localhost:7890/3
+
+   ```
+
+## Running with a Virtual Environment
+```bash
 $ python -m venv venv
 $ . venv/bin/activate
 $ pip install -e .
+$ chmod +x main.py
+$ ./main
+
+Examples | Alternates :
+      - ./main
+      - ./main -d dsn
+      - ./main -h 127.0.0.1 -p 6379
+      - ./main -h 127.0.0.1 -p 6379 -a <password>
+      - ./main --url redis://localhost:7890/3
 ```
 
 ## Release Procedure
 
-```
+```bash
 $ pip install bumpversion
 $ bumpversion patch/minor/major
 ```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+if __name__ == "__main__":
+    from dice.entry import main
+    main()


### PR DESCRIPTION
## Changes to README.md
- Introduction: Added an overview section to describe the purpose of the DiceDB CLI.
- Development Setup: Clarified the instructions for setting up a virtual environment and installing dependencies.
- Running the Project: Included detailed steps for running the project both with and without Poetry, providing flexibility for users.
- Release Procedure: Added instructions for using bumpversion for version management.
- License and Contributing: Included sections on licensing and contributing to encourage collaboration.
## Changes to main.py
- Shebang Line: Added the shebang line #!/usr/bin/env python3 at the top of the file to specify the Python interpreter.
- devs can run the cli via `./main.py` entrypoint ( if they are running cli-code locally ).
- Entry Point: Wrapped the main function call in a standard if __name__ == "__main__": block to ensure that the script can be imported without executing the main function unintentionally.